### PR TITLE
Create loader helper ensuring data is fully loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 *.egg-info
 soln.hdf5
 .pytest_cache
+build

--- a/known_broken_constraints.txt
+++ b/known_broken_constraints.txt
@@ -2,3 +2,4 @@ coverage!=5.0a3
 pylint!=2.2.0,!=2.3.0.dev0,!=2.3.0.dev1,!=2.3.0.dev2,!=2.4.0,!=2.4.1
 astroid!=2.2.0.dev0,!=2.2.0.dev1,!=2.3.0
 cython<3.0.0a8
+pytest-regtest!=2.0.0,!=2.0.1

--- a/src/disc_solver/file_format/_loaders.py
+++ b/src/disc_solver/file_format/_loaders.py
@@ -6,7 +6,7 @@ from ._containers import (
     Solution, SolutionInput, ConfigInput, Problems, InternalData, Run,
     InitialConditions, JacobianData, Solutions, MCMCVars,
 )
-from ._utils import ds_registry, _str_β_to_γ
+from ._utils import ds_registry, _str_β_to_γ, ensure_fully_loaded
 
 
 # pylint: disable=missing-docstring
@@ -571,7 +571,7 @@ def _config_loader13(group):
         v_θ_sonic_crit=group["v_θ_sonic_crit"],
         after_sonic=group["after_sonic"],
         sonic_interp_size=group["sonic_interp_size"],
-        interp_range=group["interp_range"],
+        interp_range=ensure_fully_loaded(group["interp_range"]),
         interp_slice=group["interp_slice"],
         use_E_r=None,
     )
@@ -607,7 +607,7 @@ def _config_loader14(group):
         v_θ_sonic_crit=group["v_θ_sonic_crit"],
         after_sonic=group["after_sonic"],
         sonic_interp_size=group["sonic_interp_size"],
-        interp_range=group["interp_range"],
+        interp_range=ensure_fully_loaded(group["interp_range"]),
         interp_slice=group["interp_slice"],
         use_E_r=group.attrs["use_E_r"],
     )
@@ -1038,7 +1038,7 @@ def _input_loader13(group):
     if group["interp_range"] is None:
         interp_range = None
     else:
-        interp_range = group["interp_range"]
+        interp_range = ensure_fully_loaded(group["interp_range"])
     return SolutionInput(
         start=group.attrs["start"],
         stop=group.attrs["stop"],
@@ -1093,7 +1093,7 @@ def _input_loader14(group):
     if group["interp_range"] is None:
         interp_range = None
     else:
-        interp_range = group["interp_range"]
+        interp_range = ensure_fully_loaded(group["interp_range"])
     return SolutionInput(
         start=group.attrs["start"],
         stop=group.attrs["stop"],
@@ -1252,9 +1252,9 @@ def _mcmc_vars_loader(group):
 @ds_registry.loader("slice", version=1)
 def _slice_loader(group):
     return slice(
-        group["start"],
-        group["stop"],
-        group["step"],
+        ensure_fully_loaded(group["start"]),
+        ensure_fully_loaded(group["stop"]),
+        ensure_fully_loaded(group["step"]),
     )
 
 # pylint: enable=missing-docstring

--- a/src/disc_solver/file_format/_utils.py
+++ b/src/disc_solver/file_format/_utils.py
@@ -6,7 +6,7 @@ from fractions import Fraction
 
 import attr
 
-from h5preserve import Registry
+from h5preserve import Registry, DatasetContainer
 
 ds_registry = Registry("disc_solver")
 
@@ -23,3 +23,13 @@ def get_fields(cls):
     Get the list of field names from an attr.s class
     """
     return tuple(field.name for field in attr.fields(cls))
+
+
+def ensure_fully_loaded(obj):
+    """
+    Make sure the returned object has been loaded from a dataset (i.e.
+    DatasetContainer are converted to the underlying data).
+    """
+    if isinstance(obj, DatasetContainer):
+        return obj["data"]
+    return obj


### PR DESCRIPTION
The slice and interp_range loading did not convert away from h5preserve types, add a helper to ensure that both new and existing files are correctly loaded, meaning CSVs are correctly generated.

Also limits pytest-regtest versions used, as newer ones are broken.