### PR TITLE
Latest pytest-regtest is broken, use old version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
 deps =
     pytest>=5.0
     pytest-cov
-    pytest-regtest
+    pytest-regtest==2.1.1
     py
     pytest-info-collector
     pytest-xdist


### PR DESCRIPTION
2.1.1. -> 2.2.0