### PR TITLE
Set the x-axis limit as well

### DIFF
--- a/src/disc_solver/analyse/trajectory.py
+++ b/src/disc_solver/analyse/trajectory.py
@@ -306,6 +306,7 @@ def generate_plot(
     ax.legend(loc="upper left")
     # Don't show anything below the midplane
     ax.set_ylim(bottom=0)
+    ax.set_xlim(left=0)
     ax.set_aspect('equal', adjustable='datalim')
 
     return fig


### PR DESCRIPTION
It looks like to get square grids, matplotlib may ignore the limits, setting both x and y means at least one will be followed hopefully.